### PR TITLE
PAAS-11511 yaml_include_dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name='sgmanager',
-    version='1.4.7',
+    version='1.4.8',
     packages=['sgmanager', 'sgmanager.logger', 'sgmanager.securitygroups'],
     entry_points={
         'console_scripts': ['sgmanager = sgmanager.cli:main']

--- a/sgmanager.spec
+++ b/sgmanager.spec
@@ -1,7 +1,7 @@
 %global with_check 0
 
 Name:           sgmanager
-Version:        1.4.7
+Version:        1.4.8
 Release:        1%{?dist}
 Summary:        Tooling for EC2 security groups management
 


### PR DESCRIPTION
Using only !include is prone to introducing a new file and
forgetting to include it. Swithching to inclusion of a whole
directory, where applicable, does not have this drawback.
The actuall snippet of code was "borrowed" from smoker.