### PR TITLE
really support Neutron and ignore egress rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ of passing credentials for OpenStack environments:
 * `export OS_*` from environment variables
 * `clouds.yaml` and use `--os-cloud` option
 
-## Notes
+## Important Notes
 
-- Egress rules have not been tested
+- Multiple rules with the same name are unsupported
+  (even though this is supported in latest OS).
+  This means that you probably want to delete all groups
+  before using sgmanager.
+- Egress rules are ignored temporarily.

--- a/sgmanager/rule.py
+++ b/sgmanager/rule.py
@@ -49,7 +49,9 @@ class Rule(Base):
     def to_dict(self, user=False):
         '''Convert object to dictionary, mangling options for best user view if requested.'''
         if user:
-            d = {'protocol': self.protocol}
+            d = {}
+            if self.protocol is not None:
+                d['protocol'] = self.protocol
             if self.direction != Direction.Ingress:
                 # This is kinda default
                 d['direction'] = self.direction
@@ -86,7 +88,7 @@ class Rule(Base):
                 'port_min': kwargs['port_range_min'],
                 'port_max': kwargs['port_range_max'],
                 'cidr': kwargs['remote_ip_prefix'],
-                'group': kwargs['group'].get('name')}
+                'group': kwargs['remote_group_id']}
 
         rule = cls(**info)
         rule._id = kwargs['id']
@@ -189,7 +191,7 @@ class Rule(Base):
 
     @protocol.setter
     def protocol(self, value):
-        self._protocol = Protocol(value)
+        self._protocol = Protocol(value) if value is not None else None
 
     @staticmethod
     def _check_port(port):


### PR DESCRIPTION
There are few implications with neutron:
* Groups can have same names
  → unsupported
* Returned rule objects do not have group information
  → do our best to map it back
* Returned rule objects can have remote_ip_prefix=None
  → explicitly re-create rules with proper CIDR
* Returned rule objects can have protocol=None
  → make it valid configuration, this means protocol=*
* Egress rules are actually used but we don't have sane way to use them
  → ignore them for now until sane way is found

Signed-off-by: Igor Gnatenko <igor.gnatenko@gooddata.com>