### PR TITLE
rule: register OSPF as valid protocol

### DIFF
--- a/sgmanager/rule.py
+++ b/sgmanager/rule.py
@@ -25,6 +25,7 @@ class Protocol(StrEnum):
     TCP = 'tcp'
     UDP = 'udp'
     ICMP = 'icmp'
+    OSPF = 'ospf'
 
 
 class Rule(Base):


### PR DESCRIPTION
It is not specified in the OpenStack CLI, but is valid protocol
according to OS.

Signed-off-by: Igor Gnatenko <igor.gnatenko@gooddata.com>