### PR TITLE
FEATURE: Exclude taged security groups from removing and changing

### DIFF
--- a/sgmanager/cli.py
+++ b/sgmanager/cli.py
@@ -87,6 +87,11 @@ def main(argv=None):
         'config',
         type=pathlib.Path,
     )
+    cmd_update.add_argument(
+        '-e', '--exclude-tag',
+        dest='exclude_tag',
+        default='orchestrator=terraform',
+        help='Exclude taged security groups from removing and updating. Default tag is "orchestrator=terraform"')
 
     def update(manager, args):
         manager.connection = openstack.connect(config=args)
@@ -94,7 +99,8 @@ def main(argv=None):
         manager.load_remote_groups()
         manager.update_remote_groups(dry_run=args.dry_run,
                                      threshold=args.threshold,
-                                     remove=args.remove)
+                                     remove=args.remove,
+                                     exclude_tag=args.exclude_tag)
 
     args = parser.parse_args()
     if args.debug:

--- a/sgmanager/group.py
+++ b/sgmanager/group.py
@@ -13,9 +13,10 @@ logger = logging.getLogger(__name__)
 
 class Group(Base):
     '''Single group with its rules.'''
-    def __init__(self, name, description=None, rules=None):
+    def __init__(self, name, description=None, tags=None, rules=None):
         self.name = name
         self.description = description
+        self.tags = tags
         self.rules = OrderedSet(rules)
         self._project = None
         self._id = None
@@ -26,12 +27,15 @@ class Group(Base):
             d = {}
             if self._description is not None and self.description != self.name:
                 d['description'] = self.description
+            if self.tags is not None and len(self.tags) > 0:
+                d['tags'] = tuple(self.tags)
             if len(self.rules) > 0:
                 d['rules'] = tuple(self.rules)
             return d
         else:
             return {'name': self.name,
                     'description': self.description,
+                    'tags': self.tags,
                     'rules': self.rules}
 
     @property
@@ -63,6 +67,7 @@ class Group(Base):
         # TODO: Even egress rules are supported, we will skip them
         info = {'name': kwargs['name'],
                 'description': kwargs.get('description'),
+                'tags': kwargs.get('tags'),
                 'rules': [Rule.from_remote(**rule)
                           for rule in kwargs['security_group_rules']
                           if rule['direction'] == 'ingress']}


### PR DESCRIPTION
Ensure we are not changing or removing groups managed by different _security group manager_ like using terraform for orchestration of security groups if they are taged:
```
INFO:sgmanager.manager:1 excluded changes. Security groups taged as 'orchestrator=terraform':
INFO:sgmanager.manager:  - Excluded group 'test-group-managed-by-terraform'
INFO:sgmanager.manager:1 changes to be made:
INFO:sgmanager.manager:  - Remove group 'test-group-managed-by-sgmanager' with 0 rules

```